### PR TITLE
Support sending and replying JMS text messages

### DIFF
--- a/jms/src/it/java/org/seedstack/ws/WSJmsIT.java
+++ b/jms/src/it/java/org/seedstack/ws/WSJmsIT.java
@@ -154,4 +154,12 @@ public class WSJmsIT {
         ((BindingProvider) calculatorWS).getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, "jms:topic:TEST.TOPIC?connectionName=myConnection&topicReplyToName=TEST.REPLY.TOPIC");
         calculatorWS.add(1, 1);
     }
+
+    @Test
+    public void using_text_message() {
+        CalculatorService calculatorService = new CalculatorService();
+        CalculatorWS calculatorWS = calculatorService.getCalculatorSoapJmsPort();
+        ((BindingProvider) calculatorWS).getRequestContext().put(BindingProvider.ENDPOINT_ADDRESS_PROPERTY, "jms:jndi:dynamicQueues/TEST.QUEUE?jndiInitialContextFactory=org.apache.activemq.jndi.ActiveMQInitialContextFactory&jndiConnectionFactoryName=ConnectionFactory&jndiURL=vm://localhost?broker.persistent=false&deliveryMode=NON_PERSISTENT&messageType=text");
+        assertThat(calculatorWS.add(1, 1)).isEqualTo(2);
+    }
 }


### PR DESCRIPTION
Client side, this adds support for sending JMS text messages as a client (with the non-standard messageType URI parameter specified as 'text').

On the server side, this also adds supports for replying with a text message if the request was received as a text message.

Either side, it uses the content-type specified as JMS property to find the right charset. It defaults to UTF-8 if it cannot find any explicit charset.
